### PR TITLE
Remove the 'same subnet' pre-requisite

### DIFF
--- a/source/high_availability/high_availability.rst
+++ b/source/high_availability/high_availability.rst
@@ -25,7 +25,6 @@ Prerequisites
 The HA in XiVO only works with telephony devices (i.e. phones) that support
 the notion of a primary and backup telephony server.
 
-* The master and the slave must be in the same subnet
 * If firewalling, the master must be allowed to join the slave on ports 22 and 5432
 * If firewalling, the slave must be allowed to join the master with an ICMP ping
 * Trunk registration timeout (``expiry``) should be less than 300 seconds (5 minutes)

--- a/source/high_availability/high_availability.rst
+++ b/source/high_availability/high_availability.rst
@@ -25,6 +25,8 @@ Prerequisites
 The HA in XiVO only works with telephony devices (i.e. phones) that support
 the notion of a primary and backup telephony server.
 
+* Phones must be able to reach the master and the slave (take special care if master 
+  and slave are not in the same subnet)
 * If firewalling, the master must be allowed to join the slave on ports 22 and 5432
 * If firewalling, the slave must be allowed to join the master with an ICMP ping
 * Trunk registration timeout (``expiry``) should be less than 300 seconds (5 minutes)


### PR DESCRIPTION
This requirement is unnecessary.
There is no need for xivo-1 and xivo-2 to be in the same subnet with the current High Availability implementation.

Historically, this requirement was kept in the documentation solely because we were targeting, at the beginning of XiVO Skaro (XiVO >= 1.2), to return to a Virtual IP High Availability implementation.

As of writing, this is not a target anymore neither in short nor mid term.