### PR TITLE
correcting the explanation on the monitoring parameter on XIVO

### DIFF
--- a/source/administration/interconnections/xivo_with_voip_provider.rst
+++ b/source/administration/interconnections/xivo_with_voip_provider.rst
@@ -55,10 +55,12 @@ Register tab::
 If your XiVO is behind a NAT device or a firewall, you should set the
 following::
 
-    Monitoring: 2000 milliseconds
+    Monitoring: Yes
+    
+This option will make Asterisk send a signal to the VoIP provider server every 60 seconds (default settings), so that NATs and firewall know the connection is still alive. If you want to change the value of this cycle period, you have to select the appropriate value of the following parameter :
 
-This option will make Asterisk send a signal to the VoIP provider server every 2
-seconds, so that NATs and firewall know the connection is still alive.
+    Qualify Frequency: 
+    
 
 At that point, the Asterisk command ``sip show registry`` should print a line
 showing that you are registered, meaning your trunk is established.

--- a/source/administration/interconnections/xivo_with_voip_provider.rst
+++ b/source/administration/interconnections/xivo_with_voip_provider.rst
@@ -57,7 +57,7 @@ following::
 
     Monitoring: Yes
     
-This option will make Asterisk send a signal to the VoIP provider server every 60 seconds (default settings), so that NATs and firewall know the connection is still alive. If you want to change the value of this cycle period, you have to select the appropriate value of the following parameter :
+This option will make Asterisk send a signal to the VoIP provider server every 60 seconds (default settings), so that NATs and firewall know the connection is still alive. If you want to change the value of this cycle period, you have to select the appropriate value of the following parameter ::
 
     Qualify Frequency: 
     


### PR DESCRIPTION
Correcting the explanation on the monitoring parameter on XIVO
Monitoring is about response time of the SIP Peer. The frequency of those messages can be edit with the parameter Qualify Frequency.