### PR TITLE
/usr/local/sbin/berofos-workaround : set service full path

### DIFF
--- a/source/troubleshooting/troubleshooting.rst
+++ b/source/troubleshooting/troubleshooting.rst
@@ -133,7 +133,7 @@ The following describes how to configure your XiVO and your Berofos.
     #!/bin/bash
     # Script workaround for berofos integration with a XiVO in front of PABX
 
-    res=$(service asterisk status)
+    res=$(/usr/sbin/service asterisk status)
     does_ast_run=$?
     if [ $does_ast_run -eq 0 ]; then
         /usr/bin/logger "$0 - Asterisk is running"


### PR DESCRIPTION
certainly needed since debian 8